### PR TITLE
[#PE-174] Allow all national addresses on search

### DIFF
--- a/GetMerchant/postgres_queries.ts
+++ b/GetMerchant/postgres_queries.ts
@@ -5,6 +5,7 @@ SELECT
     COALESCE( NULLIF(p.name, ''), p.full_name) AS name,
     p.description,
     p.website_url,
+    p.all_national_addresses,
     a.image_url
 FROM profile p
 JOIN agreement a ON (p.agreement_fk = a.agreement_k)
@@ -63,4 +64,4 @@ SELECT
     d.static_code,
     array_agg(d.product_category) AS product_categories
 FROM discounts_with_categories d
-GROUP BY 1,2,3,4,5,6,7,8,9`;
+GROUP BY 1,2,3,4,5,6,7,8`;

--- a/models/AddressModel.ts
+++ b/models/AddressModel.ts
@@ -2,6 +2,6 @@ import { Model } from "sequelize";
 
 export default class AddressModel extends Model {
   public readonly full_address!: string;
-  public readonly latitude!: number;
-  public readonly longitude!: number;
+  public readonly latitude!: number | undefined;
+  public readonly longitude!: number | undefined;
 }

--- a/models/MerchantProfileModel.ts
+++ b/models/MerchantProfileModel.ts
@@ -6,5 +6,6 @@ export default class MerchantProfileModel extends Model {
   public readonly image_url!: string | undefined;
   public readonly name!: string;
   public readonly profile_k!: number;
+  public readonly all_national_addresses!: boolean;
   public readonly website_url!: string | undefined;
 }

--- a/models/OfflineMerchantModel.ts
+++ b/models/OfflineMerchantModel.ts
@@ -9,7 +9,7 @@ export default class OfflineMerchantModel extends Model {
     ProductCategoryEnumModelType
   >;
   public readonly address!: string;
-  public readonly latitude!: number;
-  public readonly longitude!: number;
-  public readonly distance!: number;
+  public readonly latitude!: number | undefined;
+  public readonly longitude!: number | undefined;
+  public readonly distance!: number | undefined;
 }

--- a/openapi/index.yaml
+++ b/openapi/index.yaml
@@ -213,7 +213,6 @@ definitions:
       - name
       - productCategories
       - address
-      - distance
     properties:
       id:
         type: string
@@ -236,8 +235,6 @@ definitions:
     type: object
     required:
       - full_address
-      - latitude
-      - longitude
     properties:
       full_address:
         type: string
@@ -285,9 +282,6 @@ definitions:
 
   OfflineMerchantSearchRequest:
     type: object
-    required:
-      - userCoordinates
-      - boundingBox
     properties:
       merchantName:
         type: string


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->

#### List of Changes
<!--- Describe your changes in detail -->
- Modified postgres queries in order to mange address placeholder in case `allNationalAddresses` is set to true
- Modified openapi specs
- GetOfflineMerchants refactoring in order to disable geosearch
#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

This solves a problem while representing search data that includes CGN operator without addresses
#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
Unit and integration locally
#### Screenshots (if appropriate):

#### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Chore (nothing changes by a user perspective)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
