### PR TITLE
[#IOCOM-546] Added category based logic for "new discounts" flag

### DIFF
--- a/GetOfflineMerchants/handler.ts
+++ b/GetOfflineMerchants/handler.ts
@@ -82,7 +82,28 @@ export const GetOfflineMerchantsHandler = (
               O.map(Math.round),
               O.toUndefined
             ),
-            newDiscounts: offlineMerchant.new_discounts,
+            newDiscounts:
+              offlineMerchant.new_discounts &&
+              pipe(
+                O.fromNullable(searchRequest.productCategories),
+                O.map(filter_categories =>
+                  pipe(
+                    O.fromNullable(
+                      offlineMerchant.categories_with_new_discounts
+                    ),
+                    O.map(
+                      categories_with_new_discounts =>
+                        categories_with_new_discounts.filter(v =>
+                          filter_categories.includes(
+                            ProductCategoryFromModel(v)
+                          )
+                        ).length > 0
+                    ),
+                    O.getOrElse(() => false) // there are no categories with new discounts
+                  )
+                ),
+                O.getOrElse(() => true) // no category filter => maintain the queried flag
+              ),
             productCategories: offlineMerchant.product_categories.map(pc =>
               ProductCategoryFromModel(pc)
             )

--- a/GetOnlineMerchants/handler.ts
+++ b/GetOnlineMerchants/handler.ts
@@ -77,7 +77,24 @@ export const GetOnlineMerchantsHandler = (
           discountCodeType: DiscountCodeTypeFromModel(
             onlineMerchant.discount_code_type
           ),
-          newDiscounts: onlineMerchant.new_discounts,
+          newDiscounts:
+            onlineMerchant.new_discounts &&
+            pipe(
+              O.fromNullable(searchRequest.productCategories),
+              O.map(filter_categories =>
+                pipe(
+                  O.fromNullable(onlineMerchant.categories_with_new_discounts),
+                  O.map(
+                    categories_with_new_discounts =>
+                      categories_with_new_discounts.filter(v =>
+                        filter_categories.includes(ProductCategoryFromModel(v))
+                      ).length > 0
+                  ),
+                  O.getOrElse(() => false) // there are no categories with new discounts
+                )
+              ),
+              O.getOrElse(() => true) // no category filter => maintain the queried flag
+            ),
           productCategories: pipe(
             [...onlineMerchant.product_categories],
             AR.map(ProductCategoryFromModel)

--- a/models/OfflineMerchantModel.ts
+++ b/models/OfflineMerchantModel.ts
@@ -13,4 +13,7 @@ export default class OfflineMerchantModel extends Model {
   public readonly longitude!: number | undefined;
   public readonly distance!: number | undefined;
   public readonly new_discounts!: boolean;
+  public readonly categories_with_new_discounts?: ReadonlyArray<
+    ProductCategoryEnumModelType
+  >;
 }

--- a/models/OnlineMerchantModel.ts
+++ b/models/OnlineMerchantModel.ts
@@ -12,4 +12,7 @@ export default class OnlineMerchantModel extends Model {
   public readonly website_url!: string;
   public readonly discount_code_type!: DiscountCodeTypeEnumModel;
   public readonly new_discounts!: boolean;
+  public readonly categories_with_new_discounts?: ReadonlyArray<
+    ProductCategoryEnumModelType
+  >;
 }


### PR DESCRIPTION
#### List of Changes
"New discounts" flag depends on category filter.

#### Motivation and Context
We need to show the flag only if the operator has a new discount in the requested category.

#### How Has This Been Tested?
yarn build
yarn test

#### Screenshots (if appropriate):

#### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Chore (nothing changes by a user perspective)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

